### PR TITLE
Fix country list documentation

### DIFF
--- a/source/documentation/basic-customisation.md
+++ b/source/documentation/basic-customisation.md
@@ -142,12 +142,12 @@ country: {
 }
 ```
 
-We also need to add some options for the field. Fortunately there is a Home Office managed list of countries, so we don't need to handle this ourselves. Install `homeoffice-countries` from npm, and then add the following:
+We also need to add some options for the field. Fortunately there is a Home Office managed list of countries, so we don't need to handle this ourselves. Install `hof-util-countries` from npm, and then add the following:
 
 ```js
 country: {
   mixin: 'select',
-  options: require('homeoffice-countries').allCountries,
+  options: require('hof-util-countries')(),
   validate: 'required'
 }
 ```

--- a/source/documentation/i18n.md
+++ b/source/documentation/i18n.md
@@ -53,7 +53,7 @@ The properties available for each field vary slightly according to the field typ
 
 #### options
 
-The `options` translation for a radio/checkbox group or select element should consist - at a minimum - of a label for each option as defined in the options for the field. For example, for a yes/no radio button group:
+The `options` translation for a radio/checkbox group or select element should consist of a label for each option as defined in the options for the field. For example, for a yes/no radio button group:
 
 ```json
 {


### PR DESCRIPTION
The previous documentation yielded a broken country list because it attempted to translate the country names. Replace with the wrapper module designed to solve this issue.