### PR TITLE
Make content for pages i18n a little clearer

### DIFF
--- a/source/documentation/i18n.md
+++ b/source/documentation/i18n.md
@@ -27,16 +27,20 @@ This contains the application-wide content that applies to all pages in your app
 
 This contains page-specific content for each page of your app. The top level keys in `pages.json` correspond to the routes onto which your steps are mounted, as defined in your application config.
 
-For example, if you have a step with a route of `/personal-details` then your `pages.json` might look something like this:
+For example, to add the content for the address step we created earlier at `/address` then you would add the following to your `pages.json`:
 
 ```json
 {
-  "personal-details": {
-    "header": "Personal Details",
-    "intro": "Please provide the following details for your application"
+  "name": {
+    "header": "Personal details",
+  },
+  "address": {
+    "header": "Address details"
   }
 }
 ```
+
+The key for each section of the `pages.json` file should match the url path of the step.
 
 By default a `header` and optional `intro` are loaded for each page. If you are using a custom template for a page then you might wish to define further page-level translations here.
 


### PR DESCRIPTION
Change the examples to match the actual file contents a user would have if they are follwoing the guide.