### PR TITLE
Add link to github repo from About page

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -6,7 +6,7 @@ title: About HOF
 
 ## What is HOF?
 
-HOF (Home Office Forms) is a framework designed to assist developers in creating form-based workflows in a rapid, repeatable and secure way. It aims to reduce simple applications as much as possible to being configuration-only.
+[HOF (Home Office Forms)](https://github.com/UKHomeOfficeForms/hof) is a framework designed to assist developers in creating form-based workflows in a rapid, repeatable and secure way. It aims to reduce simple applications as much as possible to being configuration-only.
 
 ## About this documentation
 


### PR DESCRIPTION
AFAICT, there is no link to the github repo from the documentation site.