### PR TITLE
amend heading and wording in GovUK documentation for more clarity

### DIFF
--- a/wiki/Wiki_How_Tos/2.gov-uk-updates.md
+++ b/wiki/Wiki_How_Tos/2.gov-uk-updates.md
@@ -134,13 +134,14 @@ with partial
 </div>
 ```
 
-### Changes on Firearms
-#### Page headings and warnings with Checkboxes and Radio buttons(Single Page Questions)
+
+### Page headings and warnings with Checkboxes and Radio buttons(Single Page Questions)
  Page headings are included in the fieldset for single page questions with checkboxes and radio buttons using `isPageHeading`. To place warning text between the heading and a checkbox/radio button form on such pages, use `isWarning`.
 
  ```js:title=fields > index.js
  'choose-a-journey': {
     isPageHeading: true,
+    isWarning: true,
     mixin: 'radio-group',
     validate: 'required',
     options: [
@@ -151,7 +152,7 @@ with partial
     ]
   },
  ```
- `isWarning` can be used in the same way as `isPageHeading` above. It can also be configured in a behaviour:
+ `isWarning` can be configured in field/index.js as above. It can also be configured in a behaviour:
 
  ```js:title=behaviour.js
  module.exports =


### PR DESCRIPTION
`isWarning` config for checkboxes and radios has been applied in hof and can be used in all services so removed the headings referring to firearms changes and amend wording to make it clearer.