### PR TITLE
Amend session timeout warning documentation with updated hof version

### DIFF
--- a/wiki/Wiki_How_Tos/3.session-timeout-warning.md
+++ b/wiki/Wiki_How_Tos/3.session-timeout-warning.md
@@ -13,7 +13,7 @@ This is a basic documentation page to help developers use an updated version of 
 
 ## Package.json updates
 
-- Specify package to use `hof@~22.0.0`
+- Specify package to use at least `hof@~22.1.3`
 - Run `yarn install`
 
 - Make dev use the .env file (command varies on projects)


### PR DESCRIPTION
## What? 
Amend session timeout warning documentation with updated hof version
## Why? 
- To account for patch made to hof related to session timeout warning implementation
## How? 
- Updated content in /Users/rhodine.orleans-lindsay/Documents/HO/HOF/hof-guide/wiki/Wiki_How_Tos/3.session-timeout-warning.md
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have created a JIRA number for my branch (if applicable) - N/A
- [ ] I have created a JIRA number for my commit (if applicable) N/A
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] I will squash the commits before merging
