### PR TITLE
HOFF-1307: Documentation for govuk-frontend v4 update

### DIFF
--- a/wiki/Wiki_How_Tos/2.gov-uk-updates.md
+++ b/wiki/Wiki_How_Tos/2.gov-uk-updates.md
@@ -6,18 +6,19 @@ This is a basic documentation page to illustrate changes. At time of writing, it
 without a non-gov implementation in HOF.In future this will not be necessary. In order to update your project 
 you will require access to these following urls for documentation/guidance provided.
 
-
 <br>
 
-```toc
-# This code block gets replaced with the Table Of Contents
-```
+- [Useful Links](#useful-links)
+- [Version 3](#version-3)
+- [Version 4](#version-4)
 
-## Useful links
+
+# Useful links <a name="useful-links"></a>
 - [Gov UK Design System and Documentation](https://design-system.service.gov.uk)
-- [Github - Sulthans' Implementation for UKVIET](https://github.com/UKHomeOffice/end-tenancy/pull/201)
+- [Github - Sulthans' Implementation for UKVIET](https://github.com/UKHomeOffice/end-tenancy/pull/201) (version 3 update)
+- [Github - Implementation for VIPTT](https://github.com/UKHomeOffice/visa-processing-times-tool/pull/39/files) (version 4 update)
 
-
+# Version 3 <a name="version-3"></a>
 ## Package.json updates
 
 - Specify package to use `hof@20.0.0-beta.29`
@@ -338,3 +339,14 @@ townOrCity: {
     className: ['govuk-input', 'govuk-input--width-20']
   }
 ```
+
+# Version 4 <a name="version-4"></a>
+## Package.json updates
+- Specify package to use `23.0.0`
+## Breaking Changes
+From v4.10 of govuk-frontend, if you serve the assets from the GOV.UK Frontend assets folder, the assets inside the dist/govuk/assets/rebrand folder should be served correctly at <YOUR-SITE-URL>/assets/rebrand
+The following folders in your project must be moved from the `assets` folder into a `assets/rebrand` folder to avoid builds breaking:
+- js
+- scss
+- images
+e.g  e.g. `assets/images` will need to be moved to `assets/rebrand/images`.


### PR DESCRIPTION
## What? 
Add documentation for govuk-frontend v4 update [HOFF-1307](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-1307)
## Why? 
To give guidance on breaking changes after updating govuk-frontend to v4 in hof
## How? 
- organised govuk update guidance into version 3 and version 4. Added content for version 4
## Screenshots (optional)
## Anything Else? (optional)
- Content refers to using hof version  23.0.0 for the v4 update as this PR will only be merged once the hof PR is merged and v23.0.0 is released
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have created a JIRA number for my branch (if applicable)
- [x] I have created a JIRA number for my commit (if applicable)
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] I will squash the commits before merging
